### PR TITLE
0.0.77 - Adjust ES6.md example to match latest Smartdown spec for /module playables (v1.0.54 of Smartdown).

### DIFF
--- a/ES6.md
+++ b/ES6.md
@@ -1,6 +1,6 @@
 ### ES6 Module Inclusion (*work-in-progress*)
 
-This example uses the (currently experimental) `/module` qualifier to the playable to load the playable as an ES6 Module. If the module defines a `start(pThis)` function, then it will be invoked after the module is loaded, which allows the module to resemble a traditional playable with access to the playable's `this.div` and `this.env`. However, module side-effects will occur at load-time and will have no idea what playable they belong to.
+This example uses the (currently experimental) `/module` qualifier to the playable to load the playable as an ES6 Module. If the module defines a `start()` function, then it will be invoked after the module is loaded, which allows the module to resemble a traditional playable with access to the playable's `this.div` and `this.env`. However, module side-effects will occur at load-time and will have no idea what playable they belong to.
 
 [NameA](:?NameA)
 
@@ -9,14 +9,14 @@ console.log('in ModuleA');
 
 import * as Lib from './gallery/ExtensionsES6Module.js';
 
-export default function start(pThis, playable, env) {
-	const log = pThis.log;
+export default function start(playable, env) {
+	const log = this.log;
 
-	log('start', pThis);
+	log('start', this);
 
-	pThis.dependOn.NameA = () => {
+	this.dependOn.NameA = () => {
 		smartdown.setVariable('NameB', env.NameA.toUpperCase());
-		pThis.div.innerHTML = `<h1>Hello from an ES6 Module A. ${env.NameA}</h1>`;
+		this.div.innerHTML = `<h1>Hello from an ES6 Module A. ${env.NameA}</h1>`;
 	};
 
 	const nums = [12, 23, 34, 45];
@@ -37,17 +37,17 @@ console.log('in ModuleB');
 
 import * as Lib from 'https://localhost:4000/gallery/ExtensionsES6Module.js';
 
-export default function start(pThis, playable, env) {
-	const log = pThis.log;
-	log('start', pThis);
+export default function start(playable, env) {
+	const log = this.log;
+	log('start', this);
 	const nums = [12, 23, 34, 45];
 	log('sum', Lib.sum(...nums));
 	log('mult', Lib.mult(...nums));
 
 	log('Lib.note.note', Lib.note.note);
 
-	pThis.dependOn.NameB = () => {
-		pThis.div.innerHTML = `<h1>Hello from an ES6 Module B. ${env.NameB}</h1>`;
+	this.dependOn.NameB = () => {
+		this.div.innerHTML = `<h1>Hello from an ES6 Module B. ${env.NameB}</h1>`;
 	};
 
 }

--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ See [Smartdown README](https://smartdown.github.io/smartdown/#README) for more i
 - **0.0.74** - Improve Filament.md and add reactivity example.
 - **0.0.75** - Improves Filament example to use bi-directional reactivity.
 - **0.0.76** - Fix dc.js TSV file URL for D3.md dc.js example.
-
+- **0.0.77** - Adjust ES6.md example to match latest Smartdown spec for /module playables (v1.0.54 of Smartdown).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartdown-gallery",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "description": "Example Smartdown documents and associated resources that demonstrate various Smartdown features and serve as raw material for other Smartdown demos.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
0.0.77 - Adjust ES6.md example to match latest Smartdown spec for /module playables (v1.0.54 of Smartdown).
