### PR TITLE
0.0.81 - GitLab Pages, npm-watch, style fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 hide
+dist
 
 # Logs
 logs

--- a/Swatch.md
+++ b/Swatch.md
@@ -35,19 +35,9 @@ A grid of swatches:
 
 Although Smartdown swatches don't currently have any inherent reactivity with Smartdown variables, the idea of a *dynamic* swatch is easily implemented by using an output cell of type `markdown`, and inserting the appropriate swatch Smartdown code into the cell's associated variable. For example, below we have a grid of output cells which are to be formatted as `markdown` output cells.
 
-*Note: There appears to be a bug in how `markdown` cells are rendered. Instead of a grid, each cell is getting its own line. I'm guessing that there is a CSS problem where `display: inline` is not being applied in the case of a generated `[swatch]()` cell. I need to create an Issue for this.*
-
 [](:!swatch00|markdown)[](:!swatch01|markdown)[](:!swatch02|markdown)
 [](:!swatch10|markdown)[](:!swatch11|markdown)[](:!swatch12|markdown)
 [](:!swatch20|markdown)[](:!swatch21|markdown)[](:!swatch22|markdown)
-
-Meanwhile, here's a Markdown table with the same information.
-
-||||
-|:---:|:---:|:---:|
-|[](:!swatch00\|markdown)|[](:!swatch01\|markdown)|[](:!swatch02\|markdown)|
-|[](:!swatch10\|markdown)|[](:!swatch11\|markdown)|[](:!swatch12\|markdown)|
-|[](:!swatch20\|markdown)|[](:!swatch21\|markdown)|[](:!swatch22\|markdown)|
 
 And we have an associated playable (below), which periodically (once per 5 sec) changes the grid by adjusting the Smartdown within each cell to be a swatch image.
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -80,3 +80,4 @@
 - **0.0.78** - Add Swatch.md. Add Astronomy.md. Fix error in Decorations.md where a --partialborder was not closed correctly.
 - **0.0.79** - Eliminate Mathigon example and support files. Update OpenJSCAD.md to use OpenJSCAD v2.x. Update Typescript.md to correspond to new /module usage of 'this' instead of 'pThis'.
 - **0.0.80** - Adds 'http-server' dependency and 'npm run serve' command. Migrates release history from README.md to VERSIONS.md. Adds 'npm run build' script to copy relevant files into 'dist/'. Adds 'npm run publish' to publish to 'gh-pages'.
+- **0.0.81** - Remove '<style>' tag that causes output cells to be 'width: 100%' and prevents them from abutting nicely. Adds ability to publish to GitLab Pages. Replaced 'npm run serve' with 'npm run servegh' and 'npm run servegl' for GitHub/GitLab Pages, respectively. This uses npm-watch to rebuild the /dist directory upon file changes.

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,22 @@
-# Build a Gallery distribution into dist/ for gh-pages purposes.
-
+# Build a Gallery distribution into dist/
+# Usage:
+# ./build.sh
+#
+# Environment variables:
+#   TARGETTYPE=github
+#   TARGETTYPE=gitlab
+#   TARGETTYPE=local
+#
 rm -rf dist/
 mkdir dist/
 cp -r *.md dist/
 cp -r resources/ dist/resources/
 cp -r JSPsych/ dist/JSPsych/
-cp index.html dist/
+ejs ./index.ejs -o ./dist/index.html targetType=${TARGETTYPE}
 cp gussalufz-16-solved.exolve dist/
 cp DataElements.csv dist/
+if [ "$TARGETTYPE" = "local" ]; then
+  pushd dist/
+  ln -s . gallery
+  popd
+fi

--- a/github/publish.sh
+++ b/github/publish.sh
@@ -1,14 +1,10 @@
-#
-# Based upon:
-#	https://blog.bloomca.me/2017/12/15/how-to-push-folder-to-github-pages.html
-#
-
 REMOTE=`git remote get-url --push origin`
 rm -rf dist
 npm run build
 rm -rf /tmp/gallery-publish/
 cp -r dist/ /tmp/gallery-publish/
 cd /tmp/gallery-publish/
+
 git init
 git checkout -b master
 git checkout -b gh-pages

--- a/gitlab/gitlab-ci.yml
+++ b/gitlab/gitlab-ci.yml
@@ -1,0 +1,11 @@
+image: alpine:latest
+
+pages:
+  stage: deploy
+  script:
+  - echo 'Nothing to do...'
+  artifacts:
+    paths:
+    - public
+  only:
+  - master

--- a/gitlab/publish.sh
+++ b/gitlab/publish.sh
@@ -1,0 +1,18 @@
+REMOTE="git@gitlab.com:smartdown/gallerydemo.git"
+rm -rf dist
+npm run build
+rm dist/gallery
+rm -rf /tmp/gallery-publish/
+mkdir -p /tmp/gallery-publish/public/
+cp gitlab/gitlab-ci.yml /tmp/gallery-publish/.gitlab-ci.yml
+cp -r dist/ /tmp/gallery-publish/public/
+cp gitlab/index.html /tmp/gallery-publish/public/
+cd /tmp/gallery-publish/
+
+git init
+git checkout -b master
+touch .nojekyll
+git add . .nojekyll
+git commit -m "Initial commit"
+git remote add origin ${REMOTE}
+git push --force origin master

--- a/index.ejs
+++ b/index.ejs
@@ -17,21 +17,11 @@
     src="https://unpkg.com/smartdown/dist/lib/smartdown.js">
   </script>
 
-<!--
-  <link
-    rel=stylesheet
-    href="https://localhost:4000/lib/fonts.css">
-  <link
-    rel=stylesheet
-    href="https://localhost:4000/lib/smartdown.css">
-  <script
-    src="https://localhost:4000/lib/smartdown.js">
-  </script>
- -->
-
-<style>
+  <style>
 .smartdown_p .infocell-output {
-width: 100%;
+  //width: 100%;
+  outline: 1px solid red !important;
+  border: 1px solid cyan !important;
 }
   </style>
 </head>
@@ -39,6 +29,7 @@ width: 100%;
 <body
   id="smartdown-outer-container"
   class="smartdown-outer-container">
+
   <div
     class="smartdown-container"
     id="smartdown-output">
@@ -49,21 +40,18 @@ width: 100%;
   <script src="https://unpkg.com/smartdown/dist/lib/starter.js"></script>
   <script>
     window.smartdownBaseURL = 'https://unpkg.com/smartdown/dist/';
-    window.smartdownResourceURL = '/gallery/resources/';
+    window.smartdownResourceURL = '/resources/';
+    if ('<%= targetType %>' === 'github') {
+      window.smartdownResourceURL = '/gallery/resources/';
+    }
+    else if ('<%= targetType %>' === 'gitlab') {
+      window.smartdownResourceURL = '/gallerydemo/resources/';
+    }
+
     window.smartdownDefaultHome = 'Home';
     window.smartdownStarter();
   </script>
 
-<!-- 
-  <script src="https://localhost:4000/lib/calc_handlers.js"></script>
-  <script src="https://localhost:4000/lib/starter.js"></script>
-  <script>
-    window.smartdownBaseURL = 'https://localhost:4000/';
-    window.smartdownResourceURL = '/gallery/resources/';
-    window.smartdownDefaultHome = 'Home';
-    window.smartdownStarter();
-  </script>
--->
 
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "name": "smartdown-gallery",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "description": "Example Smartdown documents and associated resources that demonstrate various Smartdown features and serve as raw material for other Smartdown demos.",
   "main": "index.js",
   "scripts": {
     "rmdsstore": "find . -name '.DS_Store' -print -delete",
     "build": "./build.sh",
-    "publish": "./publish.sh",
-    "serve": "http-server -c-1"
+    "publishgh": "TARGETTYPE=github ./github/publish.sh",
+    "publishgl": "TARGETTYPE=gitlab ./gitlab/publish.sh",
+    "servegh": "(TARGETTYPE=github npm run watch &) && (http-server -c-1 dist/)",
+    "servegl": "(TARGETTYPE=gitlab npm run watch &) && (http-server -c-1 dist/)",
+    "serve": "(npm run watch &) && (http-server -c-1 dist/)",
+    "watch": "npm-watch"
   },
   "repository": {
     "type": "git",
@@ -24,6 +28,25 @@
   },
   "homepage": "https://github.com/smartdown/gallery#readme",
   "devDependencies": {
-    "http-server": "^14.1.1"
+    "ejs": "^3.1.9",
+    "http-server": "^14.1.1",
+    "npm-watch": "^0.11.0"
+  },
+  "watch": {
+    "build": {
+      "ignore": [
+        "dist/gallery",
+        "dist/**"
+      ],
+      "patterns": [
+        "./index.ejs",
+        "./resources/**",
+        "./JSPsych/**",
+        "./gussalufz-16-solved.exolve",
+        "./DataElements.csv",
+        "./*.md"
+      ],
+      "extensions": "ejs,md,js"
+    }
   }
 }


### PR DESCRIPTION
Remove '<style>' tag that causes output cells to be 'width: 100%' and prevents them from abutting nicely. Adds ability to publish to GitLab Pages. Replaced 'npm run serve' with 'npm run servegh' and 'npm run servegl' for GitHub/GitLab Pages, respectively. This uses npm-watch to rebuild the /dist directory upon file changes.