### PR TITLE
0.0.85 - Fixed Extensions.md

### DIFF
--- a/Extensions.md
+++ b/Extensions.md
@@ -146,7 +146,7 @@ this.depend = function() {
 ##### Simple JS Include
 
 ```javascript/playable
-//smartdown.include=../gallery/ExtensionsPlayableHelloWorld.js
+//smartdown.include=gallery/ExtensionsPlayableHelloWorld.js
 
 //
 // This code will be ignored and never displayed in the playable, unless OptionB is implemented.
@@ -157,7 +157,7 @@ this.depend = function() {
 
 
 ```p5js/playable
-//smartdown.include=../gallery/ExtensionsPlayableP5.js
+//smartdown.include=gallery/ExtensionsPlayableP5.js
 ```
 
 
@@ -167,7 +167,7 @@ Let's see what happens when an included file does not exist.
 
 
 ```p5js/playable/debug
-//smartdown.include=../gallery/NoSuchFile.js
+//smartdown.include=gallery/NoSuchFile.js
 ```
 
 
@@ -176,14 +176,14 @@ Let's see what happens when an included file does not exist.
 
 
 ```graphviz/playable
-//smartdown.include=../gallery/ExtensionsPlayableGraphviz.gv
+//smartdown.include=gallery/ExtensionsPlayableGraphviz.gv
 ```
 
 
 ##### UMD Inclusion
 
 ```javascript/playable/debug
-//smartdown.import=/gallery/ExtensionsPlayableUMDImport.js
+//smartdown.import=gallery/ExtensionsPlayableUMDImport.js
 
 console.log('UMD Inclusion worked');
 console.log('example', example);

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -84,3 +84,4 @@
 - **0.0.82** - Use a different CORS proxy for various examples. Improve Plotly.md, fixing an autoresize bug, and properly implementing the dynamic title example. Updated Stdlib.md examples so that they work with latest 'stdlib.js'.
 - **0.0.83** - Improved Markdown.md to demonstrate fenced code blocks with and without a language identifier.
 - **0.0.84** - Basically, a mostly useless version increment because publishing 0.0.83 failed for some reason.
+- **0.0.85** - Fixed Extensions.md so that 'gallery/' references via 'smartdown.include' and 'smartdown.import' work properly when published with a non-empty baseURL (e.g., 'smartdown/').

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartdown-gallery",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "description": "Example Smartdown documents and associated resources that demonstrate various Smartdown features and serve as raw material for other Smartdown demos.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
0.0.85
- Fixed Extensions.md so that 'gallery/' references via 'smartdown.include' and 'smartdown.import' work properly when published with a non-empty baseURL (e.g., 'smartdown/').
